### PR TITLE
Add :angry: for `mean ∘ skipmissing`

### DIFF
--- a/src/WatchJuliaBurn.jl
+++ b/src/WatchJuliaBurn.jl
@@ -98,7 +98,8 @@ const func_to_emojis = Dict(
     :download => (:(📥),),
     :sleep => (:(😴), :(💤),),
     :exit => (:(🚪),),
-    :pop! => (:(🍾), :(🏹🎈))
+    :pop! => (:(🍾), :(🏹🎈)),
+    :(mean ∘ skipmissing) => (:(😠),),
 )
 
 for func in keys(func_to_emojis)
@@ -116,9 +117,6 @@ end
 export @🥩_str
 func_to_emojis[:(raw)] = (:(🥩),)
 emoji_to_func[:(🥩"")] = (:(raw""), "")
-
-export 😠
-const 😠 = mean ∘ skipmissing
 
 include("emojify.jl")
 include("monkeycatch.jl")

--- a/src/WatchJuliaBurn.jl
+++ b/src/WatchJuliaBurn.jl
@@ -117,6 +117,9 @@ export @🥩_str
 func_to_emojis[:(raw)] = (:(🥩),)
 emoji_to_func[:(🥩"")] = (:(raw""), "")
 
+export 😠
+const 😠 = mean ∘ skipmissing
+
 include("emojify.jl")
 include("monkeycatch.jl")
 export @🐒


### PR DESCRIPTION
This comes from a recent gripe on slack. Somebody wants a shorter name for `mean ∘ skipmissing` and I figure this is a great opportunity to expand the user-base of this package.

While I'll admit :angry; is not ideal (:mean: would be better, were it a thing), I think this face looks a little mean: 😠, and I think the slight deviation is also appropriate as it reflects the semantic variation from traditional `mean`. If we used `:mean:`, folks might mistakenly think we were aliasing to Julia's `mean`.

Also, the motivation for this addition is a user's anger at not having a brief way of expressing `mean ∘ skipmissing`.