### PR TITLE
Remove duplicate comment

### DIFF
--- a/src/😃→🗿.jl
+++ b/src/😃→🗿.jl
@@ -37,7 +37,7 @@ end
 🥈🎻(😃::Tuple) = 🎻(🥇(😃))
 
 ## Allow to 🤲 a random 🎻 every ⏲️ it's printed
-struct 🎰🧵{T🧵} # RandString
+struct 🎰🧵{T🧵}
     🎻🎻🎻::T🧵
 end
 


### PR DESCRIPTION
The struct is literally named 🎰🧵, so a comment that says the same thing in a more verbose format doesn't add any value.